### PR TITLE
remove `DyadicInterval` method for other types

### DIFF
--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -10,6 +10,23 @@ EditURL = "https://github.com/lucaferranti/DedekindCutArithmetic.jl/blob/main/CH
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.2.0]
+
+### Breaking
+
+- Disallow `DyadicInterval` method on other exact reals ([#6](https://github.com/lucaferranti/DedekindCutArithmetic.jl/issues/6))
+  - **To upgrade**: replace `DyadicInterval(x)` with `refine!(x)`
+- `exact` macro now returns `RationalCaucyCut` instead of `Rational` ([#6](https://github.com/lucaferranti/DedekindCutArithmetic.jl/issues/6))
+  - **To upgrade**: No change should be needed, all operations should work with the new behavior too. The rational can be obtained using the internal function `parse_decimal`.
+
+### Fixed
+
+- Fixed bug in `exact` string macro to prevent denominator from overflowing ([#6](https://github.com/lucaferranti/DedekindCutArithmetic.jl/issues/6))
+
+### Added
+
+- Division between cuts and composite exact reals ([#6](https://github.com/lucaferranti/DedekindCutArithmetic.jl/issues/6))
+
 ## [v0.1.1](https://github.com/lucaferranti/DedekindCutArithmetic.jl/releases/tag/v0.1.1) -- 2025-04-13
 
 ### Added

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -213,7 +213,7 @@ hence when processing expressions with macros, the rounding sin has already happ
 For example, the following would fail to terminate
 
 ```julia
-@∀ x ∈ [0, 1]: x + 0.1000000000000000000001 > x + 0.1
+@∀ x ∈ ℝ: 0.1000000000000000000001 > 0.1
 ```
 
 because when parsing the literals both produce the same floating point number.
@@ -229,5 +229,5 @@ exact"0.1"
 ```
 
 ```@repl tutorial1
-@∀ x ∈ [0, 1]: x + exact"0.1000000000000000000001" > x + exact"0.1"
+@∀ x ∈ ℝ: exact"0.1000000000000000000001" > exact"0.1"
 ```

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -52,9 +52,6 @@ d1 - d2
 d1 * d2
 ```
 
-!!! warning "Warning"
-    Division is currently not supported
-
 ## Dyadic interval
 
 There is plenty of real numbers which are not dyadic, for example ``0.1, \sqrt{2},\pi`` and so on so forth. What we will want to do, we will want a [`DyadicInterval`](@ref) ``[a, b]`` with ``a,b`` dyadic reals, which bounds the value we want to approximate. These intervals can be manipulated using interval arithmetic.
@@ -73,9 +70,6 @@ An important thing to notice is that our library relies on *Kaucher interval ari
 ```@repl tutorial1
 i = DyadicInterval(3, 1)
 ```
-
-!!! warning "Warning"
-    Division is currently not supported
 
 ## Defining cuts
 
@@ -125,7 +119,7 @@ It is worth mentioning that for printing, the expression is evaluated to 53 bits
 ```
 
 !!! warning "Warning"
-    Unbounded intervals are not really supported, infinity is replaced by `big(typemax(Int))` during macro expansion.
+    Unbounded intervals are not supported yet, infinity is replaced by `big(typemax(Int))` during macro expansion.
 
 ### Square root as Dedekind cut
 

--- a/src/abstract_interface.jl
+++ b/src/abstract_interface.jl
@@ -20,26 +20,6 @@ abstract type AbstractCut <: AbstractDedekindReal end
 Base.isfinite(::AbstractDedekindReal) = true
 Base.isnan(::AbstractDedekindReal) = false
 
-"Width of the current precise appoximation of t mosthe cut"
-width(c::AbstractDedekindReal) = width(DyadicInterval(c))
-
-"Midpoint of the current most precise approximation of the cut"
-midpoint(c::AbstractDedekindReal) = midpoint(DyadicInterval(c))
-
-"Width of the current precise appoximation of t mosthe cut"
-radius(c::AbstractDedekindReal) = radius(DyadicInterval(c))
-
-"Lower bound of the real number approximated by the cut"
-low(c::AbstractDedekindReal) = low(DyadicInterval(c))
-
-"Lower bound of the real number approximated by the cut"
-high(c::AbstractDedekindReal) = high(DyadicInterval(c))
-
-"Whether or not two cuts are overlapping in the current precision"
-function overlaps(c1::AbstractDedekindReal, c2::AbstractDedekindReal)
-    overlaps(DyadicInterval(c1), DyadicInterval(c2))
-end
-
 """
 Refine the given cut to give an approximation with `precision` bits of accuracy.
 If the required accuracy cannot be achieved within `max_iter` iterations, return the current estimate

--- a/src/interval.jl
+++ b/src/interval.jl
@@ -58,7 +58,7 @@ Base.:-(d::DyadicInterval; precision = DEFAULT_PRECISION) = DyadicInterval(-d.hi
 function Base.:+(d1::AbstractDyadic, d2::AbstractDyadic; precision = DEFAULT_PRECISION)
     DyadicInterval(low(d1) + low(d2), high(d1) + high(d2))
 end
-function Base.:-(d1::DyadicInterval, d2::DyadicInterval; precision = DEFAULT_PRECISION)
+function Base.:-(d1::AbstractDyadic, d2::AbstractDyadic; precision = DEFAULT_PRECISION)
     DyadicInterval(low(d1) - high(d2), high(d1) - low(d2))
 end
 

--- a/src/interval.jl
+++ b/src/interval.jl
@@ -24,11 +24,27 @@ isbackward(d::DyadicInterval) = d.hi < d.lo
 dual(d::DyadicInterval) = DyadicInterval(d.hi, d.lo)
 
 Base.in(x::Number, i::DyadicInterval) = min(i.lo, i.hi) <= x <= max(i.lo, i.hi)
+
+"Whether or not the given dyadic intervals overlap."
 overlaps(i1::DyadicInterval, i2::DyadicInterval) = max(i1.lo, i2.lo) <= min(i1.hi, i2.hi)
+
+"Left endpoint of the dyadic interval."
 low(i::DyadicInterval) = i.lo
+
+"Right endpoint of the dyadic interval."
 high(i::DyadicInterval) = i.hi
+
+"""
+  Width of the dyadic interval.
+
+Note this is always positive, also for improper intervals.
+"""
 width(i::DyadicInterval) = abs(i.hi - i.lo)
+
+"Half the width of the given interval."
 radius(i::DyadicInterval) = width(i) >> 1
+
+"Midpoint of the dyadic interval"
 midpoint(i::DyadicInterval) = (i.lo + i.hi) >> 1
 
 refine!(i::DyadicInterval; precision = DEFAULT_PRECISION, max_iter = 1000) = i

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -92,18 +92,21 @@ function parse_decimal(s::AbstractString)
         logden += parse(BigInt, last(num_exp))
     end
     if logden < 0
-        num // 10^(-logden)
+        num // big(10)^(-logden)
     else
-        num * 10^logden
+        num * big(10)^logden
     end
 end
 
 """
-Parse a decimal literal into a Rational{BigInt}
+Parse a decimal literal into an exact real
 
 ```julia
-julia> exact"0.1"
-1//10
+julia> a = exact"0.1"
+[0.099999999999999867, 0.10000000000000009]
+
+julia> refine!(a; precision = 80)
+[0.099999999999999992, 0.10000000000000001]
 ```
 
 This is needed because literals are already parsed before constructing the AST, hence
@@ -111,5 +114,5 @@ when writing :(x - 0.1) one would get the floating point approximation of 1//10 
 exact rational.
 """
 macro exact_str(s::AbstractString)
-    parse_decimal(s)
+    RationalCauchyCut(parse_decimal(s))
 end

--- a/src/quantifiers.jl
+++ b/src/quantifiers.jl
@@ -26,7 +26,7 @@ function forall(dom::DyadicInterval, f::Function)::Bool
     low(d) > 0 && f(high(dom)) < 0 && return true
     high(d) < 0 && f(low(dom)) < 0 && return true
 
-    high(f(dom)) < 0 && return true
+    f(dom) < 0 && return true
 
     i1, i2 = split(dom)
     forall(i1, f) && forall(i2, f)

--- a/src/quantifiers.jl
+++ b/src/quantifiers.jl
@@ -2,7 +2,7 @@
 Check whether ``∃ x ∈ dom : f(x) < 0``
 """
 function exists(dom::DyadicInterval, f::Function)::Bool
-    f(midpoint(dom)) < 0 && return true
+    f(DyadicInterval(midpoint(dom))) < 0 && return true
 
     # try to avoid bisection by checking for monotonicity
     d = ForwardDiff.derivative(f, dom)
@@ -19,7 +19,7 @@ end
 Check whether ``∀ x ∈ dom : f(x) < 0``
 """
 function forall(dom::DyadicInterval, f::Function)::Bool
-    f(midpoint(dom)) >= 0 && return false
+    f(DyadicInterval(midpoint(dom))) >= 0 && return false
 
     # try to avoid bisection by checking for monotonicity
     d = ForwardDiff.derivative(f, dom)

--- a/test/test-cuts.jl
+++ b/test/test-cuts.jl
@@ -56,6 +56,19 @@ end
     fmax = my_max(f)
     ifmax = refine!(fmax)
     @test ifmax == fmax.mpa
-    @test BigFloat(width(fmax)) <= 0x1p-53
-    @test low(fmax) < 1 // 4 < high(fmax)
+    @test BigFloat(width(ifmax)) <= 0x1p-53
+    @test low(ifmax) < 1 // 4 < high(ifmax)
+end
+
+@testset "exact macro" begin
+    a = exact"0.1"
+    @test a.num == 1
+    @test a.den == 10
+
+    # check denominator doesn't overflow
+    a = exact"0.09999999999999999167332731531132594682276248931884765625"
+    b = 9999999999999999167332731531132594682276248931884765625 // big(10)^56
+
+    @test a.num == numerator(b)
+    @test a.den == denominator(b)
 end


### PR DESCRIPTION
- [x] Remove `DyadicInterval` method for other types
- [x] `exact` produces a cut now
- [x] update documentation tutorial